### PR TITLE
Add dark mode support to docs site

### DIFF
--- a/site/Readme.md
+++ b/site/Readme.md
@@ -26,3 +26,7 @@ npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
+### Dark mode
+
+Use the theme toggle in the site's navigation bar to switch between light and dark modes. The selected mode is remembered between visits.

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -8,9 +8,11 @@ module.exports = {
 	projectName: 'react-styleguidist',
 	stylesheets: ['https://fonts.googleapis.com/css?family=Bree+Serif|Open+Sans:400,400i,700'],
 	themeConfig: {
-		colorMode: {
-			disableSwitch: true,
-		},
+               colorMode: {
+                       disableSwitch: false,
+                       defaultMode: 'light',
+                       respectPrefersColorScheme: true,
+               },
 		prism: {
 			// eslint-disable-next-line import/no-extraneous-dependencies
 			theme: require('prism-react-renderer/themes/nightOwlLight'),

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -55,6 +55,15 @@
 	--ifm-h4-font-size: 1.2rem;
 }
 
+html[data-theme='dark'] {
+       --color-base: #f5f5f5;
+       --ifm-font-color-base: var(--color-base);
+       --ifm-heading-color: var(--color-base);
+       --ifm-button-color: var(--color-base);
+       --ifm-hero-text-color: var(--color-base);
+       --ifm-menu-color-background-hover: rgba(255, 255, 255, 0.15);
+}
+
 .DocSearch-Button.DocSearch-Button {
 	--docsearch-muted-color: var(--ifm-color-gray-600);
 	--docsearch-key-gradient: transparent;


### PR DESCRIPTION
## Summary
- enable color mode switching in Docusaurus config
- add CSS variables for dark palette
- document dark mode usage in site README

## Testing
- `npm test` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68644ef790508326b0dfdeb8677c3546